### PR TITLE
feat: Make intro text responsive on mobile

### DIFF
--- a/src/pages/home/styles/homepage.module.css
+++ b/src/pages/home/styles/homepage.module.css
@@ -8,6 +8,13 @@
   padding: 20px;
 }
 
+@media only screen and (max-width: 600px) {
+  .textContainer {
+    width: 90%;
+    max-width: none;
+  }
+}
+
 .textContainer h2 {
   text-align: center;
   padding-bottom: 12px;
@@ -15,8 +22,4 @@
 
 .textContainer p {
   font-size: 1.2em;
-
-  @media only screen and (max-width: 600px) {
-    font-size: 1.2em;
-  }
 }


### PR DESCRIPTION
The intro text container now spans 90% of the screen on mobile devices, improving readability.